### PR TITLE
Fix inline entity renderer example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,8 @@ use M6Web\Bundle\DraftjsBundle\Model\DraftEntity;
 
 class LinkInlineEntityRenderer extends AbstractInlineEntityRenderer
 {
+    const TAG_NAME = 'a';
+
     use InlineRendererHelperTrait;
 
     /**


### PR DESCRIPTION
I've found this issue while trying to use your bundle to render some custom DraftJS entities. Thanks for the complete documentation.

The constant `TAG_NAME` is used but not defined in the class `LinkInlineEntityRenderer` that is given as example.